### PR TITLE
Add --modelsRequire option. Permits to control the models loading order

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ var headstone = require( './' );
 var cli = meow( {
   help: [
     'Usage:',
-    '  headstone <file> [--cwd=<path>] [--models=<path>] [--configFile=<file>] [--mongoUri=<uri>]',
+    '  headstone <file> [--cwd=<path>] [--models=<path>] [--modelsRequire] [--configFile=<file>] [--mongoUri=<uri>]',
     '',
     'Example',
     '  headstone scripts/disableUsers --models=./app/models --mongoUri=mongodb://localhost/myDb'

--- a/index.js
+++ b/index.js
@@ -31,7 +31,11 @@ function startKeystone( opts ){
   debug( "Connecting to", mongoUri || "<default mongo URI>", "with mongoose", "v" + mongoose.version );
   mongoose.connect( mongoUri );
   debug( "Importing models:", path.join( opts.keystone[ "module root" ], opts.models ) );
-  keystone.import( opts.models );
+  if (opts.modelsRequire) {
+    reqmod( opts.models, process.cwd() );
+  } else {
+    keystone.import( opts.models );
+  }
 }
 
 function processFiles( files,


### PR DESCRIPTION
My case is: model A, depends on model B, but `keystone.import` seems not to know that, so when loading that way from folder `./models` i got the error `list B not found`

With this option, i can load the models in the needed order, as done in my keystone website itself, where i load the models by doing `require('./models');` and have the `./models/index.js` with

``` javascript
require('./b.js');
require('./a.js');
```
